### PR TITLE
Bump cryptography to 48.0.1 to fix OpenSSL vulnerability

### DIFF
--- a/cobo-mpc-callback-server-v2-python/requirements.txt
+++ b/cobo-mpc-callback-server-v2-python/requirements.txt
@@ -1,4 +1,4 @@
-cryptography==46.0.7
+cryptography==48.0.1
 Flask==3.1.3
 PyJWT==2.13.0
 PyYAML==6.0.2


### PR DESCRIPTION
Wheels prior to 48.0.1 bundle a vulnerable OpenSSL version (see openssl-library.org/news/secadv/20260609.txt).