### PR TITLE
Support PKCS#1 private keys in Java callback server

### DIFF
--- a/cobo-mpc-callback-server-v2-java/pom.xml
+++ b/cobo-mpc-callback-server-v2-java/pom.xml
@@ -81,6 +81,13 @@
             <version>1.15.0</version>
         </dependency>
 
+        <!-- BouncyCastle: parse PKCS#1 / PKCS#8 private keys (bcpkix pulls in bcprov + bcutil) -->
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>1.78.1</version>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>junit</groupId>
@@ -92,7 +99,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>RELEASE</version>
+            <version>5.10.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/cobo-mpc-callback-server-v2-java/src/main/java/com/cobo/callback/service/JwtService.java
+++ b/cobo-mpc-callback-server-v2-java/src/main/java/com/cobo/callback/service/JwtService.java
@@ -1,6 +1,7 @@
 package com.cobo.callback.service;
 
 import java.io.IOException;
+import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -8,10 +9,14 @@ import java.security.KeyFactory;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
-import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
 import java.util.Date;
+
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.openssl.PEMKeyPair;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 
 import com.cobo.callback.config.AppConfig;
 
@@ -26,8 +31,6 @@ public class JwtService {
     private static final String PACKAGE_DATA_CLAIM = "package_data";
     private static final String BEGIN_PUBLIC_KEY = "-----BEGIN PUBLIC KEY-----";
     private static final String END_PUBLIC_KEY = "-----END PUBLIC KEY-----";
-    private static final String BEGIN_PRIVATE_KEY = "-----BEGIN PRIVATE KEY-----";
-    private static final String END_PRIVATE_KEY = "-----END PRIVATE KEY-----";
 
     private final AppConfig config;
     private final PublicKey clientPublicKey;
@@ -111,18 +114,34 @@ public class JwtService {
         }
     }
 
+    /**
+     * Load an RSA private key from a PEM file. BouncyCastle's {@link PEMParser} auto-detects the
+     * format, so both PKCS#1 ("BEGIN RSA PRIVATE KEY") and PKCS#8 ("BEGIN PRIVATE KEY") are accepted.
+     */
     public PrivateKey loadPrivateKey(String path) throws Exception {
         byte[] keyBytes = readKeyFile(path);
-        try {
-            String keyContent = new String(keyBytes)
-                    .replace(BEGIN_PRIVATE_KEY, "")
-                    .replace(END_PRIVATE_KEY, "")
-                    .replaceAll("\\s", "");
+        try (PEMParser pemParser = new PEMParser(new StringReader(new String(keyBytes)))) {
+            Object parsed = pemParser.readObject();
+            if (parsed == null) {
+                throw new IllegalArgumentException("No PEM object found in private key file");
+            }
 
-            byte[] decoded = Base64.getDecoder().decode(keyContent);
-            KeyFactory keyFactory = KeyFactory.getInstance(ALGORITHM);
-            return keyFactory.generatePrivate(new PKCS8EncodedKeySpec(decoded));
-        } catch (InvalidKeySpecException e) {
+            JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
+            PrivateKeyInfo privateKeyInfo;
+            if (parsed instanceof PEMKeyPair) {
+                // PKCS#1: "-----BEGIN RSA PRIVATE KEY-----"
+                privateKeyInfo = ((PEMKeyPair) parsed).getPrivateKeyInfo();
+            } else if (parsed instanceof PrivateKeyInfo) {
+                // PKCS#8: "-----BEGIN PRIVATE KEY-----"
+                privateKeyInfo = (PrivateKeyInfo) parsed;
+            } else {
+                throw new IllegalArgumentException(
+                        "Unsupported private key format: " + parsed.getClass().getName());
+            }
+            return converter.getPrivateKey(privateKeyInfo);
+        } catch (IllegalArgumentException e) {
+            throw e;
+        } catch (Exception e) {
             log.error("Invalid private key format", e);
             throw new IllegalArgumentException("Invalid private key format", e);
         }

--- a/cobo-mpc-callback-server-v2-java/src/test/java/com/cobo/callback/service/JwtServiceTest.java
+++ b/cobo-mpc-callback-server-v2-java/src/test/java/com/cobo/callback/service/JwtServiceTest.java
@@ -26,6 +26,7 @@ class JwtServiceTest {
     private ObjectMapper objectMapper;
     private AppConfig appConfig;
     private String jwtPublicKeyPath;
+    private KeyPair keyPair;
 
     @BeforeEach
     void setUp() {
@@ -37,7 +38,7 @@ class JwtServiceTest {
         try {
             KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
             keyGen.initialize(2048);
-            KeyPair keyPair = keyGen.generateKeyPair();
+            keyPair = keyGen.generateKeyPair();
 
             Path privateKeyPath = Files.createTempFile("test-private", ".pem");
             Path publicKeyPath = Files.createTempFile("test-public", ".pem");
@@ -108,6 +109,70 @@ class JwtServiceTest {
         assertThrows(JwtException.class, () ->
                 jwtService.verifyToken("invalid.token.string")
         );
+    }
+
+    /**
+     * Generate keys with openssl in BOTH PKCS#1 and PKCS#8 formats, then exercise the full
+     * Java path: loadPrivateKey -> createToken (sign with private key) -> verifyToken
+     * (verify with the openssl-derived public key). Both formats must succeed.
+     */
+    @Test
+    void testOpensslKeysPkcs1AndPkcs8() throws Exception {
+        Path dir = Files.createTempDirectory("openssl-keys");
+
+        Path priPkcs1 = dir.resolve("callback-server-pri.pem");        // PKCS#1 (openssl genrsa)
+        Path priPkcs8 = dir.resolve("callback-server-pri-pkcs8.pem");  // PKCS#8 (converted)
+        Path pub = dir.resolve("callback-server-pub.key");             // SPKI public key
+
+        // 1. PKCS#1 private key (exactly what the doc's `openssl genrsa` produces)
+        runOpenssl("genrsa", "-out", priPkcs1.toString(), "2048");
+        // 2. public key derived from it (doc command: openssl rsa -in pri.pem -pubout)
+        runOpenssl("rsa", "-in", priPkcs1.toString(), "-pubout", "-out", pub.toString());
+        // 3. convert the SAME private key to PKCS#8 (no key regeneration)
+        runOpenssl("pkcs8", "-topk8", "-nocrypt", "-in", priPkcs1.toString(), "-out", priPkcs8.toString());
+
+        // sanity: files really are the two different formats
+        assertTrue(new String(Files.readAllBytes(priPkcs1)).contains("-----BEGIN RSA PRIVATE KEY-----"),
+                "expected PKCS#1 header");
+        assertTrue(new String(Files.readAllBytes(priPkcs8)).contains("-----BEGIN PRIVATE KEY-----"),
+                "expected PKCS#8 header");
+
+        String payload = "{\"hello\":\"world\"}";
+
+        // PKCS#1: load -> sign -> verify with openssl-derived public key
+        String decodedFromPkcs1 = signAndVerify(priPkcs1.toString(), pub.toString(), payload);
+        assertEquals(payload, decodedFromPkcs1, "PKCS#1 private key round-trip failed");
+
+        // PKCS#8: load -> sign -> verify with the SAME openssl-derived public key
+        String decodedFromPkcs8 = signAndVerify(priPkcs8.toString(), pub.toString(), payload);
+        assertEquals(payload, decodedFromPkcs8, "PKCS#8 private key round-trip failed");
+
+        // Both formats are the same underlying key, so the public key produces identical results
+        assertEquals(decodedFromPkcs1, decodedFromPkcs8);
+    }
+
+    private String signAndVerify(String privateKeyPath, String publicKeyPath, String payload) {
+        AppConfig cfg = new AppConfig();
+        cfg.setServiceName("test-service");
+        cfg.setTokenExpireMinutes(30);
+        cfg.setServicePrivateKeyPath(privateKeyPath);
+        cfg.setClientPublicKeyPath(publicKeyPath);
+
+        JwtService svc = new JwtService(cfg);
+        String token = svc.createToken(payload);
+        return svc.verifyToken(token);
+    }
+
+    private void runOpenssl(String... args) throws Exception {
+        java.util.List<String> cmd = new java.util.ArrayList<>();
+        cmd.add("openssl");
+        for (String a : args) {
+            cmd.add(a);
+        }
+        Process p = new ProcessBuilder(cmd).redirectErrorStream(true).start();
+        byte[] out = p.getInputStream().readAllBytes();
+        int code = p.waitFor();
+        assertEquals(0, code, "openssl " + String.join(" ", args) + " failed:\n" + new String(out));
     }
 
     @Test


### PR DESCRIPTION
The doc-generated key (`openssl genrsa`) is PKCS#1, but loadPrivateKey only accepted PKCS#8, so the server failed to start with the documented key. Switch loadPrivateKey to BouncyCastle's PEMParser + JcaPEMKeyConverter, which auto-detects PKCS#1 and PKCS#8 (and supports encrypted/EC keys for future use), removing the hand-rolled DER wrapping.

- pom.xml: declare bcpkix-jdk18on:1.78.1 (aligns with existing bcprov); pin junit-jupiter to 5.10.2 (RELEASE failed to resolve transitive deps)
- JwtServiceTest: add openssl-based test covering both key formats

Verified end-to-end: project builds, server boots and loads both PKCS#1 and PKCS#8 keys, and /v2/check (verifyToken -> createToken) returns status 0 / APPROVE for both formats.